### PR TITLE
1.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+# Copyright 2024 The MathWorks, Inc.
+name: Release Artifacts
+
+on:
+  release:
+    types: [created]
+
+env:
+  go_version: 1.22.2
+
+jobs:
+  release-linux:
+    runs-on: ubuntu-latest
+    env:
+      artifact: mjssetup-glnxa64.tar.gz
+
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.go_version }}
+
+    - name: Run unit tests
+      run: go test ./...
+
+    - name: Build executable
+      run: env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o mjssetup cmd/mjssetup/main.go
+
+    - name: Run executable
+      run: ./mjssetup -help
+
+    - name: Create tar file
+      run: tar -czvf ${{ env.artifact }} mjssetup
+
+    - name: Upload artifact
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release upload ${{ github.event.release.tag_name }} ${{ env.artifact }}
+
+  release-windows:
+    runs-on: windows-latest
+    env:
+      artifact: mjssetup-win64.zip
+
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.go_version }}
+
+    - name: Run unit tests
+      run: go test ./...
+
+    - name: Build executable
+      run: env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o mjssetup.exe cmd/mjssetup/main.go
+
+    - name: Run executable
+      run: ./mjssetup.exe -help
+
+    - name: Create zip file
+      run: Compress-Archive -Path mjssetup.exe -Destination ${{ env.artifact }}
+
+    - name: Upload artifact
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release upload ${{ github.event.release.tag_name }} ${{ env.artifact }}

--- a/README.md
+++ b/README.md
@@ -4,24 +4,25 @@ Use the mjssetup tool to create shared secrets, signed client certificates, and 
 You do not require access to a MATLAB installation.
 For information about security configurations for MATLAB Job Scheduler clusters, see [MATLAB Job Scheduler Cluster Security](https://www.mathworks.com/help/matlab-parallel-server/set-matlab-job-scheduler-cluster-security.html).
 
-## Build Setup Tool
+## Installation
 
-To use the setup tool, you must first compile the mjssetup executable.
+You can download pre-compiled binaries for Linux&reg; and Windows&reg; from the [Releases](https://github.com/mathworks/mjssetup/releases) page.
 
-To download a zip file of this repository, at the top of this repository page, select Code > Download ZIP.
-Alternatively, to clone this repository to your computer with Git installed, run the following command on your operating system's command line:
+### Installation on Linux
 
-```
-git clone https://github.com/mathworks/mjssetup
-```
+1. Navigate to the [Releases](https://github.com/mathworks/mjssetup/releases) page.
+2. Download the latest `mjssetup-glnxa64.tar.gz` file from the assets section of the latest release.
+3. To extract the binary, in the terminal, run `tar -xzf mjssetup-glnxa64.tar.gz`.
 
-To compile the mjssetup executable from the source code, you must use Go version 1.21.4 or later.
-Use Go to compile the mjssetup executable:
-```
-go build -o mjssetup cmd/mjssetup/main.go
-```
+### Installation on Windows
+
+1. Navigate to the [Releases](https://github.com/mathworks/mjssetup/releases) page.
+2. Download the latest `mjssetup-win64.zip` file from the assets section of the latest release.
+3. To extract the binary, unzip the `mjssetup-win64.zip` file.
 
 ## Usage
+
+### Usage on Linux
 
 `mjssetup <command> [<args>]` executes the specified command using the specified input arguments.
 - `command` - Command to execute.
@@ -38,7 +39,27 @@ For example, display the help text for the `create-shared-secret` command:
 mjssetup create-shared-secret -help
 ```
 
+### Usage on Windows
+
+`mjssetup.exe <command> [<args>]` executes the specified command using the specified input arguments.
+- `command` - Command to execute.
+- `args` - Inputs to the command to execute. The types of the inputs depend on the command.
+
+To display the help text for mjssetup, run
+```
+mjssetup.exe -help
+```
+
+You can also display help text for a specific command.
+For example, display the help text for the `create-shared-secret` command:
+```
+mjssetup.exe create-shared-secret -help
+```
+
 ### Examples
+
+The following examples assume you are running on Linux.
+To run the examples on Windows, replace `mjssetup` with `mjssetup.exe`.
 
 Create a shared secret to establish trust within a cluster.
 Specify the `create-shared-secret` command and a name for the shared secret file.
@@ -77,6 +98,21 @@ For example, create a cluster profile for the cluster "cluster-name", cluster ho
 The command creates a cluster profile file, "mjs-profile.json".
 ```
 mjssetup create-profile -name "cluster-name" -host "cluster-host" -secretfile "secret.json" -outfile "mjs-profile.json"
+```
+
+## Build Setup Tool from Source Code
+
+To download a zip file of this repository, at the top of this repository page, select Code > Download ZIP.
+Alternatively, to clone this repository to your computer with Git installed, run the following command on your operating system's command line:
+
+```
+git clone https://github.com/mathworks/mjssetup
+```
+
+To compile the mjssetup executable from the source code, you must use Go version 1.21.4 or later.
+Use Go to compile the mjssetup executable:
+```
+go build -o mjssetup cmd/mjssetup/main.go
 ```
 
 ## License

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mathworks/mjssetup
 
-go 1.21.4
+go 1.22.2
 
 require github.com/stretchr/testify v1.8.4
 

--- a/internal/keytool/keytool_test.go
+++ b/internal/keytool/keytool_test.go
@@ -261,6 +261,10 @@ func TestOpenFileForWrite(t *testing.T) {
 	tmpFile := filepath.Join(tmpDir, "to-write.txt")
 	gotWriter, err := openFileForWrite(tmpFile)
 	require.NoError(t, err, "error opening file for write")
+	t.Cleanup(func() {
+		err := gotWriter.Close()
+		require.NoError(t, err, "error closing file")
+	})
 	require.NotNil(t, gotWriter, "writer returned from openFileForWrite should not be nil")
 }
 


### PR DESCRIPTION
- You can now download pre-compiled mjssetup binaries for Linux and Windows from the Releases page on GitHub: https://github.com/mathworks/mjssetup/releases.
- mjssetup now uses Go version 1.22.2.